### PR TITLE
Fix typo in platform.system() call.

### DIFF
--- a/p4clean.py
+++ b/p4clean.py
@@ -309,7 +309,7 @@ class P4Clean:
                 try:
                     os.remove(filename)
                 except:
-                    if platform.systemt() == 'Windows':
+                    if platform.system() == 'Windows':
                         try:
                             # Second try on Windows. Maybe the file was read
                             # only?


### PR DESCRIPTION
In the error case, so easy to miss...
