### PR TITLE
Remove untracked symlinks to directories.

### DIFF
--- a/p4clean.py
+++ b/p4clean.py
@@ -119,6 +119,15 @@ class Perforce(object):
                 if platform.system() == 'Windows':
                     local_file = local_file.lower()
                 local_files.append(local_file)
+	    # os.walk() treats symlinks to directories as if they 
+	    # are directories, but we need to treat them as files.
+	    for directory in directories:
+		local_file = os.path.join(path, directory)
+		if os.path.islink(local_file):
+		    if platform.system() == 'Windows':
+			local_file = local_file.lower()
+		    local_files.append(local_file)
+		
         untracked_files = set(local_files) - set(depot_files)
         return list(untracked_files)
 


### PR DESCRIPTION
We have to deal with the fact os.walk() treat symlinks to directories as if they were directories (returning them in the dirname list of the tuple), but we need to treat them as files.
