### PR TITLE
Compile exclusion_list into a regular expresion object

### DIFF
--- a/p4clean.py
+++ b/p4clean.py
@@ -182,16 +182,15 @@ class P4CleanConfig(object):
 
         # chain args and config file exclusion lists
         exclusion_list = args_exclusion_list + config_exclusion_list
-        # Exlude p4clean config file (path for *nix + windows)
-        exclusion_list.append('*/' + P4CleanConfig.CONFIG_FILENAME)
-        exclusion_list.append('*\\' + P4CleanConfig.CONFIG_FILENAME)
+        # Exlude p4clean config file
+        exclusion_list.append(os.path.join('*', P4CleanConfig.CONFIG_FILENAME))
         self.exclusion_regex = self._compute_regex(exclusion_list)
 
     def is_excluded(self, filename):
-        return re.match(self.exclusion_regex, filename) is not None
+        return self.exclusion_regex.match(filename) is not None
 
     def _compute_regex(self, exclusion_list):
-        return r'|'.join([fnmatch.translate(x) for x in exclusion_list]) or r'$.'
+        return re.compile(r'|'.join([fnmatch.translate(x) for x in exclusion_list]) or r'$.')
 
     def _config_file_path(self, root):
         """ Return absolute config file path. Return None if non-existent."""


### PR DESCRIPTION
Since the regular expression match occurs against every file, I was looking to see if it could be made any faster.  I thought that using fnmatch.fnmatch() against each element in the exclusion_list might be faster, since fnmatch() is usually much faster than regular expression in C code.  I wrote benchmark that compared the two with the list of files from the Python-2.7 distribution.  I was surprised to find that fnmatch() was much slower, until I looked at the implementation and found that it converted the glob pattern into a regular expression under the hood.   For 200 iterations, fnmatch() took 4.44 seconds, while re.match() took 1.47 seconds.

But l then realized that re.match() was recompiling the regex for each comparison.  Since we're using the same pattern for each file, we can compile it once and match against that regular expression object.  The same benchmark completed in 0.57 seconds, nearly 3 times as fast.

I also used os.path.join() to create the path for excluding the .p4clean config file, figuring that one pattern in the list would be faster than two.

This change took about 5 seconds off the runtime of "p4clean -n" off my benchmark dirty workspace.
